### PR TITLE
Update __init__.py for use with CTIE framework

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -339,7 +339,7 @@ class xmldsig(object):
         else:
             cert_chain = cert
 
-        self.payload_c14n = self._get_payload_c14n(method, c14n_algorithm=c14n_algorithm)
+        self.payload_c14n = self._get_payload_c14n(method, c14n_algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315")
         self.digest = self._get_digest(self.payload_c14n, self._get_digest_method_by_tag(self.digest_alg))
 
         signed_info = SubElement(self.sig_root, ds_tag("SignedInfo"), nsmap=self.namespaces)


### PR DESCRIPTION
the digest always has to be canonicalized inclusively, even if the signedinfo has to be canonicalized exlusively (at least for use in the CTIE DDJ Framework)
